### PR TITLE
Expose Argo CD server through load balancer

### DIFF
--- a/infra/argocd/argocd-ingress-passthrough.yaml
+++ b/infra/argocd/argocd-ingress-passthrough.yaml
@@ -10,7 +10,7 @@ metadata:
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
 spec:
   rules:
-    - host: argocd-79.174.84.176.sslip.io
+    - host: argocd.79.174.84.176.sslip.io
       http:
         paths:
           - path: /

--- a/infra/argocd/argocd-server-service.yaml
+++ b/infra/argocd/argocd-server-service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: argocd-server
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: argocd-server
+    app.kubernetes.io/part-of: argocd
+    app.kubernetes.io/component: server
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 79.174.84.176
+  externalTrafficPolicy: Cluster
+  ports:
+    - name: https
+      port: 443
+      targetPort: 8080
+    - name: http
+      port: 80
+      targetPort: 8080
+  selector:
+    app.kubernetes.io/name: argocd-server
+    app.kubernetes.io/part-of: argocd


### PR DESCRIPTION
## Summary
- add a dedicated LoadBalancer service for the Argo CD server that uses the public IP 79.174.84.176
- align the Argo CD ingress host with the sslip.io domain that matches the public address

## Testing
- not run (infrastructure configuration change)


------
https://chatgpt.com/codex/tasks/task_e_68d6e0ae3378832a9c80b5926a7f6cf5