### PR TITLE
Fix hello ingress backend

### DIFF
--- a/infra/base/ingress.yaml
+++ b/infra/base/ingress.yaml
@@ -1,8 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: argocd-ui
-  namespace: argocd
+  name: hello
   annotations:
     kubernetes.io/ingress.class: traefik
     cert-manager.io/cluster-issuer: letsencrypt
@@ -10,16 +9,16 @@ spec:
   ingressClassName: traefik
   tls:
     - hosts:
-        - argocd.79.174.84.176.sslip.io
-      secretName: argocd-tls
+        - hello.79.174.84.176.sslip.io
+      secretName: hello-tls
   rules:
-    - host: argocd.79.174.84.176.sslip.io
+    - host: hello.79.174.84.176.sslip.io
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: argocd-server
+                name: hello-svc
                 port:
-                  number: 443
+                  number: 80


### PR DESCRIPTION
## Summary
- update the base ingress to target the hello service instead of the Argo CD server
- align the host and TLS secret names with the hello application

## Testing
- not run (kustomize not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6e247d428832abfd7dc9b06e2e3f7