### PR TITLE
Fix ingress to target hello service

### DIFF
--- a/infra/base/ingress.yaml
+++ b/infra/base/ingress.yaml
@@ -1,25 +1,17 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: argocd-ui
-  namespace: argocd
+  name: hello
   annotations:
     kubernetes.io/ingress.class: traefik
-    cert-manager.io/cluster-issuer: letsencrypt
 spec:
-  ingressClassName: traefik
-  tls:
-    - hosts:
-        - argocd.79.174.84.176.sslip.io
-      secretName: argocd-tls
   rules:
-    - host: argocd.79.174.84.176.sslip.io
-      http:
+    - http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: argocd-server
+                name: hello-svc
                 port:
-                  number: 443
+                  number: 80


### PR DESCRIPTION
## Summary
- retarget the hello ingress at the hello-svc backend instead of the Argo CD server
- drop hard-coded namespace and TLS settings so the manifest works in different environments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6e29e652c832a9d06a653d620d9c1