### PR TITLE
Add Contour applications for test and prod environments

### DIFF
--- a/infra/argocd/contour-prod.yaml
+++ b/infra/argocd/contour-prod.yaml
@@ -1,0 +1,34 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: contour-prod
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://charts.projectcontour.io
+    chart: contour
+    targetRevision: 15.0.2
+    helm:
+      releaseName: contour-prod
+      values: |
+        contour:
+          ingressClass:
+            name: contour-prod
+            default: true
+        envoy:
+          service:
+            type: LoadBalancer
+            externalTrafficPolicy: Cluster
+            annotations:
+              projectcontour.io/public-access: "true"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: contour-prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true

--- a/infra/argocd/contour-test.yaml
+++ b/infra/argocd/contour-test.yaml
@@ -1,0 +1,33 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: contour-test
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://charts.projectcontour.io
+    chart: contour
+    targetRevision: 15.0.2
+    helm:
+      releaseName: contour-test
+      values: |
+        contour:
+          ingressClass:
+            name: contour-test
+            default: false
+        envoy:
+          service:
+            type: ClusterIP
+            annotations:
+              projectcontour.io/in-cluster-only: "true"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: contour-test
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - ApplyOutOfSyncOnly=true


### PR DESCRIPTION
## Summary
- add Argo CD application to deploy Contour in the test environment with an internal Envoy service
- add Argo CD application to deploy Contour in the production environment with an external LoadBalancer

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d6ea223000832a9d3d3d20bbe50877