### PR TITLE
Remove root ArgoCD applications

### DIFF
--- a/clusters/prod/apps.yaml
+++ b/clusters/prod/apps.yaml
@@ -1,45 +1,62 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: env-prod
+  name: backend-prod
   namespace: argocd
 spec:
   project: default
   source:
     repoURL: https://github.com/boldrqwe/k8s.git
     targetRevision: main
-    path: clusters/prod
-    directory: { recurse: true }
+    path: apps/backend/overlays/prod
   destination:
     server: https://kubernetes.default.svc
-    namespace: argocd
+    namespace: prod
   syncPolicy:
-    automated: { prune: true, selfHeal: true }
-    syncOptions: [ CreateNamespace=true ]
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
-metadata: { name: backend-prod, namespace: argocd }
+metadata:
+  name: frontend-prod
+  namespace: argocd
 spec:
   project: default
-  source: { repoURL: https://github.com/boldrqwe/k8s.git, targetRevision: main, path: apps/backend/overlays/prod }
-  destination: { server: https://kubernetes.default.svc, namespace: prod }
-  syncPolicy: { automated: { prune: true, selfHeal: true }, syncOptions: [CreateNamespace=true] }
+  source:
+    repoURL: https://github.com/boldrqwe/k8s.git
+    targetRevision: main
+    path: apps/frontend/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
-metadata: { name: frontend-prod, namespace: argocd }
+metadata:
+  name: db-prod
+  namespace: argocd
 spec:
   project: default
-  source: { repoURL: https://github.com/boldrqwe/k8s.git, targetRevision: main, path: apps/frontend/overlays/prod }
-  destination: { server: https://kubernetes.default.svc, namespace: prod }
-  syncPolicy: { automated: { prune: true, selfHeal: true }, syncOptions: [CreateNamespace=true] }
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata: { name: db-prod, namespace: argocd }
-spec:
-  project: default
-  source: { repoURL: https://github.com/boldrqwe/k8s.git, targetRevision: main, path: apps/db/overlays/prod }
-  destination: { server: https://kubernetes.default.svc, namespace: prod }
-  syncPolicy: { automated: { prune: true, selfHeal: true }, syncOptions: [CreateNamespace=true] }
+  source:
+    repoURL: https://github.com/boldrqwe/k8s.git
+    targetRevision: main
+    path: apps/db/overlays/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/clusters/test/apps.yaml
+++ b/clusters/test/apps.yaml
@@ -1,45 +1,62 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: env-test
+  name: backend-test
   namespace: argocd
 spec:
   project: default
   source:
     repoURL: https://github.com/boldrqwe/k8s.git
     targetRevision: main
-    path: clusters/test
-    directory: { recurse: true }
+    path: apps/backend/overlays/test
   destination:
     server: https://kubernetes.default.svc
-    namespace: argocd
+    namespace: test
   syncPolicy:
-    automated: { prune: true, selfHeal: true }
-    syncOptions: [ CreateNamespace=true ]
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
-metadata: { name: backend-test, namespace: argocd }
+metadata:
+  name: frontend-test
+  namespace: argocd
 spec:
   project: default
-  source: { repoURL: https://github.com/boldrqwe/k8s.git, targetRevision: main, path: apps/backend/overlays/test }
-  destination: { server: https://kubernetes.default.svc, namespace: test }
-  syncPolicy: { automated: { prune: true, selfHeal: true }, syncOptions: [CreateNamespace=true] }
+  source:
+    repoURL: https://github.com/boldrqwe/k8s.git
+    targetRevision: main
+    path: apps/frontend/overlays/test
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: test
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
 ---
 apiVersion: argoproj.io/v1alpha1
 kind: Application
-metadata: { name: frontend-test, namespace: argocd }
+metadata:
+  name: db-test
+  namespace: argocd
 spec:
   project: default
-  source: { repoURL: https://github.com/boldrqwe/k8s.git, targetRevision: main, path: apps/frontend/overlays/test }
-  destination: { server: https://kubernetes.default.svc, namespace: test }
-  syncPolicy: { automated: { prune: true, selfHeal: true }, syncOptions: [CreateNamespace=true] }
----
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata: { name: db-test, namespace: argocd }
-spec:
-  project: default
-  source: { repoURL: https://github.com/boldrqwe/k8s.git, targetRevision: main, path: apps/db/overlays/test }
-  destination: { server: https://kubernetes.default.svc, namespace: test }
-  syncPolicy: { automated: { prune: true, selfHeal: true }, syncOptions: [CreateNamespace=true] }
+  source:
+    repoURL: https://github.com/boldrqwe/k8s.git
+    targetRevision: main
+    path: apps/db/overlays/test
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: test
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary
- remove the env-level ArgoCD root applications from the test and prod clusters
- retain only backend, frontend, and db child applications with consistent configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7b92f3404832a929eb247ad9d5e88