### PR TITLE
Update GHCR image references and frontend API URLs

### DIFF
--- a/apps/backend/base/deployment.yaml
+++ b/apps/backend/base/deployment.yaml
@@ -13,6 +13,7 @@ spec:
       containers:
       - name: backend
         image: backend:latest
+        imagePullPolicy: Always
         ports: [{ containerPort: 8080 }]
         env:
         - { name: DB_HOST, value: "postgres" }

--- a/apps/backend/overlays/prod/kustomization.yaml
+++ b/apps/backend/overlays/prod/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: prod
 resources: ["../../base"]
 images:
   - name: backend
-    newName: ghcr.io/boldrqwe/instructions_backend
+    newName: ghcr.io/boldrqwe/instructions
     newTag: latest
 patches:
   - path: patch-deployment.yaml

--- a/apps/backend/overlays/test/kustomization.yaml
+++ b/apps/backend/overlays/test/kustomization.yaml
@@ -4,7 +4,7 @@ namespace: test
 resources: ["../../base"]
 images:
   - name: backend
-    newName: ghcr.io/boldrqwe/instructions_backend
+    newName: ghcr.io/boldrqwe/instructions
     newTag: latest
 patches:
   - path: patch-deployment.yaml

--- a/apps/frontend/base/deployment.yaml
+++ b/apps/frontend/base/deployment.yaml
@@ -13,6 +13,7 @@ spec:
       containers:
       - name: frontend
         image: frontend:latest
+        imagePullPolicy: Always
         ports: [{ containerPort: 80 }]
         env:
         - name: VITE_API_URL

--- a/apps/frontend/overlays/prod/patch-deployment.yaml
+++ b/apps/frontend/overlays/prod/patch-deployment.yaml
@@ -1,4 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata: { name: frontend }
-spec: { replicas: 2 }
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+        - name: frontend
+          env:
+            - name: VITE_API_URL
+              value: "http://api.79.174.84.176.sslip.io"

--- a/apps/frontend/overlays/test/patch-deployment.yaml
+++ b/apps/frontend/overlays/test/patch-deployment.yaml
@@ -1,4 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata: { name: frontend }
-spec: { replicas: 1 }
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: frontend
+          env:
+            - name: VITE_API_URL
+              value: "http://api-test.79.174.84.176.sslip.io"


### PR DESCRIPTION
## Summary
- update backend and frontend deployments to always pull images
- point backend overlays at the GHCR image location
- configure frontend overlays to use the new API endpoints for test and prod

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7f8a491a0832a8db322cb2f947147