### PR TITLE
Split dependency installer into resumable steps

### DIFF
--- a/scripts/install-dependencies.d/10-system-packages.sh
+++ b/scripts/install-dependencies.d/10-system-packages.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/../lib/install-deps-common.sh"
+
+require_pkg_manager
+
+log "Updating package repositories"
+update_repos
+
+log "Installing base packages"
+install_packages
+

--- a/scripts/install-dependencies.d/20-kubectl.sh
+++ b/scripts/install-dependencies.d/20-kubectl.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/../lib/install-deps-common.sh"
+
+require_pkg_manager
+
+if install_kubectl; then
+  log "kubectl installation step finished"
+else
+  err "Failed to install kubectl"
+  exit 1
+fi
+

--- a/scripts/install-dependencies.d/30-helm.sh
+++ b/scripts/install-dependencies.d/30-helm.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/../lib/install-deps-common.sh"
+
+require_pkg_manager
+
+if install_helm; then
+  log "Helm installation step finished"
+else
+  err "Failed to install Helm"
+  exit 1
+fi
+

--- a/scripts/install-dependencies.d/40-argocd-cli.sh
+++ b/scripts/install-dependencies.d/40-argocd-cli.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "$SCRIPT_DIR/../lib/install-deps-common.sh"
+
+require_pkg_manager
+
+if install_argocd_cli; then
+  log "Argo CD CLI installation step finished"
+else
+  warn "Skipping Argo CD CLI installation"
+fi
+

--- a/scripts/install-dependencies.sh
+++ b/scripts/install-dependencies.sh
@@ -1,204 +1,62 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-log() {
-  echo "[INFO] $*"
-}
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+LIB_DIR="$SCRIPT_DIR/lib"
+STEPS_DIR="$SCRIPT_DIR/install-dependencies.d"
 
-err() {
-  echo "[ERROR] $*" >&2
-}
+source "$LIB_DIR/install-deps-common.sh"
 
-ensure_root() {
-  if [[ $EUID -ne 0 ]]; then
-    exec sudo -E bash "$0" "$@"
+run_step() {
+  local step_path="$1" state_dir="$2"
+  local step_name
+  step_name="$(basename "$step_path")"
+  local marker="$state_dir/${step_name}.ok"
+
+  if [[ -f "$marker" ]]; then
+    log "Skipping step ${step_name} (already completed)"
+    return 0
   fi
-}
 
-PKG_MANAGER=""
-
-detect_pkg_manager() {
-  if command -v apt-get >/dev/null 2>&1; then
-    PKG_MANAGER="apt"
-  elif command -v dnf >/dev/null 2>&1; then
-    PKG_MANAGER="dnf"
-  elif command -v yum >/dev/null 2>&1; then
-    PKG_MANAGER="yum"
-  elif command -v zypper >/dev/null 2>&1; then
-    PKG_MANAGER="zypper"
+  log "Running step ${step_name}"
+  if bash "$step_path"; then
+    touch "$marker"
+    log "Step ${step_name} completed"
   else
-    err "Unsupported package manager. Install dependencies manually."
-    exit 1
+    err "Step ${step_name} failed"
+    return 1
   fi
-}
-
-update_repos() {
-  case "$PKG_MANAGER" in
-    apt)
-      export DEBIAN_FRONTEND=noninteractive
-      apt-get update
-      ;;
-    dnf)
-      dnf makecache --refresh -y
-      ;;
-    yum)
-      yum makecache -y
-      ;;
-    zypper)
-      zypper refresh
-      ;;
-  esac
-}
-
-install_packages() {
-  local packages=(curl openssl ca-certificates gnupg tar gzip git jq)
-  case "$PKG_MANAGER" in
-    apt)
-      packages+=(lsb-release apt-transport-https software-properties-common gettext-base)
-      ;;
-    dnf|yum)
-      packages+=(gettext)
-      ;;
-    zypper)
-      packages+=(gettext-tools)
-      ;;
-  esac
-
-  case "$PKG_MANAGER" in
-    apt)
-      apt-get install -y "${packages[@]}"
-      ;;
-    dnf)
-      dnf install -y "${packages[@]}"
-      ;;
-    yum)
-      yum install -y "${packages[@]}"
-      ;;
-    zypper)
-      zypper --non-interactive install -y "${packages[@]}"
-      ;;
-  esac
-}
-
-install_kubectl() {
-  if command -v kubectl >/dev/null 2>&1; then
-    return
-  fi
-
-  log "Installing kubectl"
-
-  local version="v1.29"
-  case "$PKG_MANAGER" in
-    apt)
-      install_kubectl_apt "$version"
-      ;;
-    dnf|yum)
-      install_kubectl_yum "$version"
-      ;;
-    zypper)
-      install_kubectl_zypper "$version"
-      ;;
-  esac
-}
-
-install_kubectl_apt() {
-  local version="$1"
-  local keyring="/etc/apt/keyrings/kubernetes-apt-keyring.gpg"
-
-  install -m 0755 -d /etc/apt/keyrings
-
-  (
-    set -euo pipefail
-    tmp_key="$(mktemp)"
-    trap 'rm -f "$tmp_key"' EXIT
-    curl -fsSL "https://pkgs.k8s.io/core:/stable:/${version}/deb/Release.key" -o "$tmp_key"
-    gpg --yes --dearmor -o "$keyring" "$tmp_key"
-  )
-
-  chmod 0644 "$keyring"
-
-  cat <<EOF_LIST >/etc/apt/sources.list.d/kubernetes.list
-deb [signed-by=$keyring] https://pkgs.k8s.io/core:/stable:/${version}/deb/ /
-EOF_LIST
-  apt-get update
-  apt-get install -y kubectl
-}
-
-install_kubectl_yum() {
-  local version="$1"
-  cat <<EOF_REPO >/etc/yum.repos.d/kubernetes.repo
-[kubernetes]
-name=Kubernetes
-baseurl=https://pkgs.k8s.io/core:/stable:/${version}/rpm/
-enabled=1
-gpgcheck=1
-gpgkey=https://pkgs.k8s.io/core:/stable:/${version}/rpm/repodata/repomd.xml.key
-EOF_REPO
-  if [[ "$PKG_MANAGER" == "dnf" ]]; then
-    dnf install -y kubectl
-  else
-    yum install -y kubectl
-  fi
-}
-
-install_kubectl_zypper() {
-  local version="$1"
-  zypper addrepo --refresh \
-    "https://pkgs.k8s.io/core:/stable:/${version}/rpm/" kubernetes
-  rpm --import "https://pkgs.k8s.io/core:/stable:/${version}/rpm/repodata/repomd.xml.key"
-  zypper --non-interactive install -y kubectl
-}
-
-install_helm() {
-  if command -v helm >/dev/null 2>&1; then
-    return
-  fi
-  log "Installing Helm"
-  curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
-}
-
-install_argocd_cli() {
-  if command -v argocd >/dev/null 2>&1; then
-    return
-  fi
-
-  local arch="$(uname -m)"
-  case "$arch" in
-    x86_64|amd64)
-      arch="amd64"
-      ;;
-    arm64|aarch64)
-      arch="arm64"
-      ;;
-    *)
-      err "Unsupported architecture for Argo CD CLI: $arch"
-      return
-      ;;
-  esac
-
-  log "Installing Argo CD CLI"
-
-  (
-    set -euo pipefail
-    tmp_dir="$(mktemp -d)"
-    trap 'rm -rf "$tmp_dir"' EXIT
-    version="$(curl -fsSL https://api.github.com/repos/argoproj/argo-cd/releases/latest | jq -r '.tag_name')"
-    curl -fsSL -o "$tmp_dir/argocd" \
-      "https://github.com/argoproj/argo-cd/releases/download/${version}/argocd-linux-${arch}"
-    install -m 0755 "$tmp_dir/argocd" /usr/local/bin/argocd
-  )
 }
 
 main() {
   ensure_root "$@"
   detect_pkg_manager
+  export PKG_MANAGER
   log "Using package manager: $PKG_MANAGER"
-  update_repos
-  install_packages
-  install_kubectl
-  install_helm
-  install_argocd_cli || true
+
+  local state_dir
+  state_dir="$(init_state_dir)"
+
+  if [[ ! -d "$STEPS_DIR" ]]; then
+    err "Steps directory '$STEPS_DIR' not found"
+    exit 1
+  fi
+
+  shopt -s nullglob
+  local steps=("$STEPS_DIR"/*.sh)
+  shopt -u nullglob
+
+  if [[ ${#steps[@]} -eq 0 ]]; then
+    err "No dependency installation steps found in '$STEPS_DIR'"
+    exit 1
+  fi
+
+  for step in "${steps[@]}"; do
+    run_step "$step" "$state_dir"
+  done
+
   log "All dependencies installed."
 }
 
 main "$@"
+

--- a/scripts/lib/install-deps-common.sh
+++ b/scripts/lib/install-deps-common.sh
@@ -1,0 +1,204 @@
+log() {
+  echo "[INFO] $*"
+}
+
+warn() {
+  echo "[WARN] $*" >&2
+}
+
+err() {
+  echo "[ERROR] $*" >&2
+}
+
+ensure_root() {
+  if [[ $EUID -ne 0 ]]; then
+    exec sudo -E bash "$0" "$@"
+  fi
+}
+
+STATE_DIR_DEFAULT="/var/lib/k8s-dependency-installer"
+
+init_state_dir() {
+  local dir="${STATE_DIR:-$STATE_DIR_DEFAULT}"
+  mkdir -p "$dir"
+  echo "$dir"
+}
+
+detect_pkg_manager() {
+  if command -v apt-get >/dev/null 2>&1; then
+    PKG_MANAGER="apt"
+  elif command -v dnf >/dev/null 2>&1; then
+    PKG_MANAGER="dnf"
+  elif command -v yum >/dev/null 2>&1; then
+    PKG_MANAGER="yum"
+  elif command -v zypper >/dev/null 2>&1; then
+    PKG_MANAGER="zypper"
+  else
+    err "Unsupported package manager. Install dependencies manually."
+    exit 1
+  fi
+}
+
+require_pkg_manager() {
+  if [[ -z "${PKG_MANAGER:-}" ]]; then
+    detect_pkg_manager
+  fi
+}
+
+update_repos() {
+  case "$PKG_MANAGER" in
+    apt)
+      export DEBIAN_FRONTEND=noninteractive
+      apt-get update
+      ;;
+    dnf)
+      dnf makecache --refresh -y
+      ;;
+    yum)
+      yum makecache -y
+      ;;
+    zypper)
+      zypper refresh
+      ;;
+  esac
+}
+
+install_packages() {
+  local packages=(curl openssl ca-certificates gnupg tar gzip git jq)
+  case "$PKG_MANAGER" in
+    apt)
+      packages+=(lsb-release apt-transport-https software-properties-common gettext-base)
+      ;;
+    dnf|yum)
+      packages+=(gettext)
+      ;;
+    zypper)
+      packages+=(gettext-tools)
+      ;;
+  esac
+
+  case "$PKG_MANAGER" in
+    apt)
+      apt-get install -y "${packages[@]}"
+      ;;
+    dnf)
+      dnf install -y "${packages[@]}"
+      ;;
+    yum)
+      yum install -y "${packages[@]}"
+      ;;
+    zypper)
+      zypper --non-interactive install -y "${packages[@]}"
+      ;;
+  esac
+}
+
+install_kubectl() {
+  if command -v kubectl >/dev/null 2>&1; then
+    return 0
+  fi
+
+  log "Installing kubectl"
+
+  local version="v1.29"
+  case "$PKG_MANAGER" in
+    apt)
+      install_kubectl_apt "$version"
+      ;;
+    dnf|yum)
+      install_kubectl_yum "$version"
+      ;;
+    zypper)
+      install_kubectl_zypper "$version"
+      ;;
+  esac
+}
+
+install_kubectl_apt() {
+  local version="$1"
+  local keyring="/etc/apt/keyrings/kubernetes-apt-keyring.gpg"
+
+  install -m 0755 -d /etc/apt/keyrings
+
+  (
+    set -euo pipefail
+    tmp_key="$(mktemp)"
+    trap 'rm -f "$tmp_key"' EXIT
+    curl -fsSL "https://pkgs.k8s.io/core:/stable:/${version}/deb/Release.key" -o "$tmp_key"
+    gpg --yes --dearmor -o "$keyring" "$tmp_key"
+  )
+
+  chmod 0644 "$keyring"
+
+  cat <<EOF_LIST >/etc/apt/sources.list.d/kubernetes.list
+deb [signed-by=$keyring] https://pkgs.k8s.io/core:/stable:/${version}/deb/ /
+EOF_LIST
+  apt-get update
+  apt-get install -y kubectl
+}
+
+install_kubectl_yum() {
+  local version="$1"
+  cat <<EOF_REPO >/etc/yum.repos.d/kubernetes.repo
+[kubernetes]
+name=Kubernetes
+baseurl=https://pkgs.k8s.io/core:/stable:/${version}/rpm/
+enabled=1
+gpgcheck=1
+gpgkey=https://pkgs.k8s.io/core:/stable:/${version}/rpm/repodata/repomd.xml.key
+EOF_REPO
+  if [[ "$PKG_MANAGER" == "dnf" ]]; then
+    dnf install -y kubectl
+  else
+    yum install -y kubectl
+  fi
+}
+
+install_kubectl_zypper() {
+  local version="$1"
+  zypper addrepo --refresh \
+    "https://pkgs.k8s.io/core:/stable:/${version}/rpm/" kubernetes
+  rpm --import "https://pkgs.k8s.io/core:/stable:/${version}/rpm/repodata/repomd.xml.key"
+  zypper --non-interactive install -y kubectl
+}
+
+install_helm() {
+  if command -v helm >/dev/null 2>&1; then
+    return 0
+  fi
+  log "Installing Helm"
+  curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+}
+
+install_argocd_cli() {
+  if command -v argocd >/dev/null 2>&1; then
+    return 0
+  fi
+
+  local arch="$(uname -m)"
+  case "$arch" in
+    x86_64|amd64)
+      arch="amd64"
+      ;;
+    arm64|aarch64)
+      arch="arm64"
+      ;;
+    *)
+      err "Unsupported architecture for Argo CD CLI: $arch"
+      return 1
+      ;;
+  esac
+
+  log "Installing Argo CD CLI"
+
+  (
+    set -euo pipefail
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "$tmp_dir"' EXIT
+    version="$(curl -fsSL https://api.github.com/repos/argoproj/argo-cd/releases/latest | jq -r '.tag_name')"
+    curl -fsSL -o "$tmp_dir/argocd" \
+      "https://github.com/argoproj/argo-cd/releases/download/${version}/argocd-linux-${arch}"
+    install -m 0755 "$tmp_dir/argocd" /usr/local/bin/argocd
+  )
+}
+


### PR DESCRIPTION
## Summary
- split the dependency installer into discrete step scripts that can be resumed independently
- add a shared helper library and state tracking so completed dependency stages are skipped on reruns
- update the main dependency installer to execute each step sequentially using the shared helpers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9481369fc832aaf6b78954129ff9e