### PR TITLE
Switch stack management to Argo CD apps

### DIFF
--- a/charts/demo-app/Chart.yaml
+++ b/charts/demo-app/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: demo-app
+description: Demo static frontend and echo API with ingress
+version: 0.1.0
+appVersion: "1.0.0"
+type: application

--- a/charts/demo-app/templates/_helpers.tpl
+++ b/charts/demo-app/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{- define "demo-app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "demo-app.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "demo-app.labels" -}}
+helm.sh/chart: {{ include "demo-app.chart" . }}
+{{ include "demo-app.selectorLabels" . }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "demo-app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "demo-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "demo-app.chart" -}}
+{{ .Chart.Name }}-{{ .Chart.Version }}
+{{- end -}}

--- a/charts/demo-app/templates/configmap.yaml
+++ b/charts/demo-app/templates/configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "demo-app.fullname" . }}-content
+  labels:
+    {{- include "demo-app.labels" . | nindent 4 }}
+data:
+  index.html: |
+    <!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="utf-8">
+        <title>{{ .Values.siteTitle | default (.Values.envName | title) }}</title>
+      </head>
+      <body>
+        <main>
+          <h1>{{ .Values.envName | title }} environment</h1>
+          <p>Everything is up.</p>
+        </main>
+      </body>
+    </html>
+  robots.txt: |
+{{ .Values.robots | indent 4 }}
+  sitemap.xml: |
+    <?xml version='1.0' encoding='UTF-8'?>
+    <urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'>
+      <url><loc>https://{{ .Values.ingress.host }}/</loc></url>
+    </urlset>

--- a/charts/demo-app/templates/deployment-api.yaml
+++ b/charts/demo-app/templates/deployment-api.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "demo-app.fullname" . }}-api
+  labels:
+    {{- include "demo-app.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.api.replicas }}
+  selector:
+    matchLabels:
+      app: {{ include "demo-app.fullname" . }}-api
+  template:
+    metadata:
+      labels:
+        app: {{ include "demo-app.fullname" . }}-api
+        {{- include "demo-app.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+      containers:
+        - name: api
+          image: {{ .Values.api.image }}
+          env:
+            - name: PORT
+              value: {{ printf "%d" .Values.api.port | quote }}
+          ports:
+            - containerPort: {{ .Values.api.port }}
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          resources:
+            {{- toYaml .Values.api.resources | nindent 12 }}

--- a/charts/demo-app/templates/deployment-web.yaml
+++ b/charts/demo-app/templates/deployment-web.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "demo-app.fullname" . }}-web
+  labels:
+    {{- include "demo-app.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.web.replicas }}
+  selector:
+    matchLabels:
+      app: {{ include "demo-app.fullname" . }}-web
+  template:
+    metadata:
+      labels:
+        app: {{ include "demo-app.fullname" . }}-web
+        {{- include "demo-app.selectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+      containers:
+        - name: web
+          image: {{ .Values.web.image }}
+          ports:
+            - containerPort: 80
+          volumeMounts:
+            - name: html
+              mountPath: /usr/share/nginx/html
+          resources:
+            {{- toYaml .Values.web.resources | nindent 12 }}
+      volumes:
+        - name: html
+          configMap:
+            name: {{ include "demo-app.fullname" . }}-content

--- a/charts/demo-app/templates/ingress.yaml
+++ b/charts/demo-app/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.ingress.enabled .Values.ingress.host }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "demo-app.fullname" . }}-site
+  labels:
+    {{- include "demo-app.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-http
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/hsts: "true"
+    nginx.ingress.kubernetes.io/hsts-max-age: "31536000"
+    nginx.ingress.kubernetes.io/proxy-body-size: "32m"
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tlsSecret }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "demo-app.fullname" . }}-web
+                port:
+                  number: 80
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "demo-app.fullname" . }}-api
+                port:
+                  number: 80
+{{- end }}

--- a/charts/demo-app/templates/service-api.yaml
+++ b/charts/demo-app/templates/service-api.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "demo-app.fullname" . }}-api
+  labels:
+    {{- include "demo-app.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: {{ include "demo-app.fullname" . }}-api
+  ports:
+    - name: http
+      port: 80
+      targetPort: {{ .Values.api.port }}

--- a/charts/demo-app/templates/service-web.yaml
+++ b/charts/demo-app/templates/service-web.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "demo-app.fullname" . }}-web
+  labels:
+    {{- include "demo-app.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: {{ include "demo-app.fullname" . }}-web
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80

--- a/charts/demo-app/values.yaml
+++ b/charts/demo-app/values.yaml
@@ -1,0 +1,31 @@
+envName: prod
+fullnameOverride: ""
+robots: |
+  User-agent: *
+  Allow: /
+siteTitle: "Demo"
+web:
+  replicas: 2
+  image: nginx:1.25-alpine
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 300m
+      memory: 256Mi
+api:
+  replicas: 1
+  image: ealen/echo-server:0.8.10
+  port: 8080
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 128Mi
+ingress:
+  enabled: true
+  host: ""
+  tlsSecret: ""

--- a/manifests/kyverno-policies/disallow-privileged.yaml
+++ b/manifests/kyverno-policies/disallow-privileged.yaml
@@ -1,0 +1,20 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: disallow-privileged
+spec:
+  validationFailureAction: enforce
+  background: true
+  rules:
+    - name: check-privileged
+      match:
+        resources:
+          kinds:
+            - Pod
+      validate:
+        message: Privileged containers are not allowed.
+        pattern:
+          spec:
+            containers:
+              - =(securityContext):
+                  =(privileged): false

--- a/manifests/kyverno-policies/kustomization.yaml
+++ b/manifests/kyverno-policies/kustomization.yaml
@@ -1,0 +1,3 @@
+resources:
+  - disallow-privileged.yaml
+  - require-runasnonroot.yaml

--- a/manifests/kyverno-policies/require-runasnonroot.yaml
+++ b/manifests/kyverno-policies/require-runasnonroot.yaml
@@ -1,0 +1,32 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: require-runasnonroot
+spec:
+  validationFailureAction: enforce
+  background: true
+  rules:
+    - name: run-as-non-root
+      match:
+        resources:
+          kinds:
+            - Pod
+      exclude:
+        resources:
+          namespaces:
+            - kube-system
+            - kube-public
+            - kyverno
+            - cert-manager
+            - ingress-nginx
+            - argocd
+      validate:
+        message: Containers must set runAsNonRoot true.
+        anyPattern:
+          - spec:
+              securityContext:
+                runAsNonRoot: true
+          - spec:
+              containers:
+                - securityContext:
+                    runAsNonRoot: true

--- a/manifests/network-policies/kustomization.yaml
+++ b/manifests/network-policies/kustomization.yaml
@@ -1,0 +1,4 @@
+resources:
+  - prod-default-deny.yaml
+  - prod-allow-web.yaml
+  - prod-allow-api.yaml

--- a/manifests/network-policies/prod-allow-api.yaml
+++ b/manifests/network-policies/prod-allow-api.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prod-api
+  namespace: prod
+spec:
+  podSelector:
+    matchLabels:
+      app: prod-api
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: ingress-nginx
+        - podSelector:
+            matchLabels:
+              app: prod-web
+      ports:
+        - port: 8080
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: prod
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/instance: postgres-prod
+      ports:
+        - port: 5432
+    - to: []
+      ports:
+        - port: 53
+          protocol: UDP

--- a/manifests/network-policies/prod-allow-web.yaml
+++ b/manifests/network-policies/prod-allow-web.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-prod-web
+  namespace: prod
+spec:
+  podSelector:
+    matchLabels:
+      app: prod-web
+  ingress:
+    - from: []
+      ports:
+        - port: 80
+  egress:
+    - to: []
+      ports:
+        - port: 53
+          protocol: UDP

--- a/manifests/network-policies/prod-default-deny.yaml
+++ b/manifests/network-policies/prod-default-deny.yaml
@@ -1,0 +1,10 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny-all
+  namespace: prod
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/scripts/install-kyverno-resume.sh
+++ b/scripts/install-kyverno-resume.sh
@@ -6,8 +6,9 @@ main() {
   ensure_requirements
   export KUBECONFIG="${KUBECONFIG:-/etc/rancher/k3s/k3s.yaml}"
 
-  install_kyverno_manifests
-  apply_baseline_policies
+  resync_argocd_application kyverno
+  resync_argocd_application kyverno-policies
+  wait_for_kyverno_deployments
   wait_for_certificates
   print_summary
 }
@@ -19,7 +20,7 @@ ensure_root() {
 }
 
 ensure_requirements() {
-  local bins=(kubectl curl base64)
+  local bins=(kubectl base64)
   for bin in "${bins[@]}"; do
     if ! command -v "$bin" >/dev/null 2>&1; then
       echo "[ERROR] Required command '$bin' not found. Install it before running." >&2
@@ -28,91 +29,29 @@ ensure_requirements() {
   done
 }
 
-install_kyverno_manifests() {
-  local manifest_url="https://github.com/kyverno/kyverno/releases/latest/download/install.yaml"
-  local tmp
-  tmp="$(mktemp)"
-  curl -fsSL "$manifest_url" -o "$tmp"
-  trap 'rm -f "$tmp"' RETURN
-
-  kubectl apply --server-side --force-conflicts -f "$tmp"
-
-  mapfile -t deployments < <(kubectl -n kyverno get deployments -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
-
-  if [[ ${#deployments[@]} -eq 0 ]]; then
-    echo "[ERROR] No Kyverno deployments were found in the 'kyverno' namespace." >&2
-    echo "        Check the manifest at $manifest_url and try again." >&2
-    exit 1
+resync_argocd_application() {
+  local app="$1"
+  if kubectl -n argocd get application "$app" >/dev/null 2>&1; then
+    kubectl -n argocd patch application "$app" --type merge \
+      -p '{"metadata":{"annotations":{"argocd.argoproj.io/refresh":"hard"}}}' >/dev/null
+  else
+    echo "[WARN] Argo CD application '$app' not found in namespace argocd." >&2
   fi
+}
 
+wait_for_kyverno_deployments() {
+  local deployments
+  mapfile -t deployments < <(kubectl -n kyverno get deployments -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null || true)
   local deploy
   for deploy in "${deployments[@]}"; do
-    kubectl -n kyverno rollout status "deployment/${deploy}" --timeout=10m
+    if [[ -n "$deploy" ]]; then
+      kubectl -n kyverno rollout status "deployment/${deploy}" --timeout=10m || true
+    fi
   done
 }
 
-apply_baseline_policies() {
-  cat <<'EOCPOL' | kubectl apply -f -
-apiVersion: kyverno.io/v1
-kind: ClusterPolicy
-metadata:
-  name: disallow-privileged
-spec:
-  validationFailureAction: enforce
-  background: true
-  rules:
-    - name: check-privileged
-      match:
-        resources:
-          kinds:
-            - Pod
-      validate:
-        message: Privileged containers are not allowed.
-        pattern:
-          spec:
-            containers:
-              - =(securityContext):
-                  =(privileged): false
-EOCPOL
-
-  cat <<'EOCPOL' | kubectl apply -f -
-apiVersion: kyverno.io/v1
-kind: ClusterPolicy
-metadata:
-  name: require-runasnonroot
-spec:
-  validationFailureAction: enforce
-  background: true
-  rules:
-    - name: run-as-non-root
-      match:
-        resources:
-          kinds:
-            - Pod
-      exclude:
-        resources:
-          namespaces:
-            - kube-system
-            - kube-public
-            - kyverno
-            - cert-manager
-            - ingress-nginx
-            - argocd
-      validate:
-        message: Containers must set runAsNonRoot true.
-        anyPattern:
-          - spec:
-              securityContext:
-                runAsNonRoot: true
-          - spec:
-              containers:
-                - securityContext:
-                    runAsNonRoot: true
-EOCPOL
-}
-
 wait_for_certificates() {
-  local namespaces=(argocd prod test observability logging tracing)
+  local namespaces=(argocd prod test observability logging tracing kubernetes-dashboard)
   local ns cert
   for ns in "${namespaces[@]}"; do
     for cert in $(kubectl -n "$ns" get certificates.cert-manager.io -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
@@ -122,13 +61,14 @@ wait_for_certificates() {
 }
 
 print_summary() {
-  local host_argo host_grafana host_logs host_trace host_site host_test
+  local host_argo host_grafana host_logs host_trace host_site host_test host_dashboard
   host_argo="$(kubectl -n argocd get ingress argocd -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || echo 'N/A')"
   host_grafana="$(kubectl -n observability get ingress grafana -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || echo 'N/A')"
   host_logs="$(kubectl -n logging get ingress opensearch -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || echo 'N/A')"
   host_trace="$(kubectl -n tracing get ingress tracing -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || echo 'N/A')"
   host_site="$(kubectl -n prod get ingress prod-site -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || echo 'N/A')"
   host_test="$(kubectl -n test get ingress test-site -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || echo 'N/A')"
+  host_dashboard="$(kubectl -n kubernetes-dashboard get ingress kubernetes-dashboard -o jsonpath='{.spec.rules[0].host}' 2>/dev/null || echo 'N/A')"
 
   local argo_pwd pg_prod pg_test
   argo_pwd="$(kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath='{.data.password}' 2>/dev/null | base64 -d || echo 'N/A')"
@@ -137,7 +77,7 @@ print_summary() {
 
   cat <<EOR
 ========================================
-Kyverno installation complete.
+Kyverno reconciliation complete.
 Public endpoints:
   Argo CD : https://${host_argo}
   Grafana : https://${host_grafana}
@@ -145,11 +85,13 @@ Public endpoints:
   Trace   : https://${host_trace}
   PROD    : https://${host_site}
   TEST    : https://${host_test}
+  K8s UI  : https://${host_dashboard}
 
 Credentials:
   Argo CD admin password: ${argo_pwd}
   PostgreSQL PROD DSN: postgresql://app:${pg_prod}@postgres-prod-postgresql.prod.svc.cluster.local:5432/appdb
   PostgreSQL TEST DSN: postgresql://app:${pg_test}@postgres-test-postgresql.test.svc.cluster.local:5432/appdb
+  Kubernetes dashboard token: kubectl -n kubernetes-dashboard create token kubernetes-dashboard
 
 Health checks:
   curl -k https://${host_site}/api/health


### PR DESCRIPTION
## Summary
- generate Argo CD Application resources to deploy the stack, including demo apps, databases, observability, logging, tracing and cluster policies
- add a reusable Helm chart for the demo web/API workloads and check in manifests for network and Kyverno policies
- expose the Kubernetes dashboard through Argo CD with TLS, update the Kyverno resume helper, and document the new flow and dashboard access

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d95d2eadf0832aab7593ea03f2c99c