### PR TITLE
Add Argo CD applications for instructions overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@
 
 > При необходимости добавьте также **pgAdmin**: `https://pgadmin.79.174.84.176.sslip.io` (ns `db-tools`).
 
+## Argo CD
+
+Применить Argo CD приложения можно командой:
+
+```bash
+kubectl apply -n argocd -f argocd/apps/
+```
+
+UI доступен по ссылке: https://argo.79.174.84.176.sslip.io
+
 ## Подготовка окружения
 
 Перед запуском основного скрипта [`scripts/install.sh`](scripts/install.sh) выполните установку системных зависимостей (CLI-инструменты, бинарники `kubectl`/`helm`, утилита `argocd`) при помощи помощника [`scripts/install-dependencies.sh`](scripts/install-dependencies.sh). Скрипт автоматически определит пакетный менеджер (APT/YUM/DNF/Zypper) и поставит требуемые пакеты.

--- a/argocd/apps/prod.yaml
+++ b/argocd/apps/prod.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: instructions-prod
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/boldrqwe/instructions.git
+    targetRevision: main
+    path: clusters/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: instructions-test
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/boldrqwe/instructions.git
+    targetRevision: main
+    path: clusters/test
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: test
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/argocd/apps/test.yaml
+++ b/argocd/apps/test.yaml
@@ -1,0 +1,41 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: instructions-prod
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/boldrqwe/instructions.git
+    targetRevision: main
+    path: clusters/prod
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: prod
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: instructions-test
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/boldrqwe/instructions.git
+    targetRevision: main
+    path: clusters/test
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: test
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
## Summary
- add Argo CD application manifests for the instructions prod and test overlays with automated sync enabled
- document how to apply the Argo CD apps and where to access the UI

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbc3d33a74832ab0e1baa557f7508d